### PR TITLE
feat: Update OpenAI chat model to gpt-4o-mini

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -1,5 +1,6 @@
 openai_embedding_model          = "text-embedding-3-small"
-openai_chat_model               = "gpt-4.1-mini-2025-04-14"
+openai_chat_model               = "gpt-4o-mini"
+#openai_chat_model               = "gpt-4.1-mini-2025-04-14" 
 openai_embedding_model_dimensions = "768"
 pinecone_environment            = "us-east-1"
 pinecone_index_name             = "basic-rag"

--- a/main.tf
+++ b/main.tf
@@ -306,3 +306,5 @@ resource "aws_ecs_service" "frontend" {
 output "app_url" {
   value = "http://${aws_lb.main.dns_name}"
 }
+
+# Rerunning workflow


### PR DESCRIPTION
This PR updates the default OpenAI chat model used by the backend service from gpt-4.1-mini to gpt-4o-mini.
The gpt-4o-mini model is faster and more cost-effective, which is better for a portfolio project. This also serves as a test of the CI/CD pipeline for configuration changes. The openai_chat_model variable in config.tfvars was updated.